### PR TITLE
ci: add daily latest Aptos TS SDK compatibility workflow

### DIFF
--- a/.github/workflows/ts-sdk-latest-compatibility.yml
+++ b/.github/workflows/ts-sdk-latest-compatibility.yml
@@ -1,0 +1,52 @@
+name: TS SDK Latest Compatibility
+
+on:
+  schedule:
+    # Every day at 02:00 UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ts-sdk-latest-compatibility-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CI: true
+
+jobs:
+  build-and-test-with-latest-ts-sdk:
+    name: Build and Test with latest @aptos-labs/ts-sdk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Setup pnpm 10.11.0
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Upgrade @aptos-labs/ts-sdk to latest across workspace
+        run: pnpm -r up @aptos-labs/ts-sdk@latest
+
+      - name: Show resolved @aptos-labs/ts-sdk versions
+        run: pnpm -r list @aptos-labs/ts-sdk --depth 0
+
+      - name: Build all packages
+        run: pnpm build
+
+      - name: Run all tests
+        run: pnpm test

--- a/.github/workflows/ts-sdk-latest-compatibility.yml
+++ b/.github/workflows/ts-sdk-latest-compatibility.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Show resolved @aptos-labs/ts-sdk versions
         run: pnpm -r list @aptos-labs/ts-sdk --depth 0
 
+      - name: Ensure lockfile has only latest @aptos-labs/ts-sdk
+        run: |
+          LATEST="$(pnpm view @aptos-labs/ts-sdk version)"
+          echo "Latest @aptos-labs/ts-sdk: ${LATEST}"
+          export LATEST
+          node -e "const fs=require('fs');const latest=process.env.LATEST;const lock=fs.readFileSync('pnpm-lock.yaml','utf8');const matches=[...lock.matchAll(/'@aptos-labs\\/ts-sdk@([^']+)'/g)];const versions=[...new Set(matches.map((m)=>m[1].split('(')[0]))].sort();console.log('Resolved versions:',versions.join(', ')||'(none)');const old=versions.filter((v)=>v!==latest);if(old.length){console.error('Found non-latest versions:',old.join(', '));process.exit(1);}"
+
       - name: Build all packages
         run: pnpm build
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a dedicated GitHub Actions workflow to validate compatibility with the latest `@aptos-labs/ts-sdk`
- trigger the workflow daily via cron and allow manual runs via `workflow_dispatch`
- in CI runtime, upgrade `@aptos-labs/ts-sdk` to `latest` across workspace before running checks
- add a hard check that fails if `pnpm-lock.yaml` resolves any non-latest `@aptos-labs/ts-sdk` versions
- keep build/test steps to validate compilation and test compatibility when version resolution is clean

## Why
This catches breakages early when upstream Aptos TS SDK releases changes that affect this project. The lockfile-version assertion also prevents silent mixed-version states that can hide or confuse compatibility issues.

## Workflow behavior
1. Install dependencies from lockfile
2. Upgrade `@aptos-labs/ts-sdk` to latest in CI runtime
3. Print resolved SDK versions for debugging
4. Assert lockfile resolves only the latest SDK version
5. Build all packages
6. Run all tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2353702c-a461-42e9-adbc-21b822bf8be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2353702c-a461-42e9-adbc-21b822bf8be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

