### PR TITLE
fix(ci): initialize pnpm before enabling pnpm cache

### DIFF
--- a/.github/workflows/ts-sdk-latest-compatibility.yml
+++ b/.github/workflows/ts-sdk-latest-compatibility.yml
@@ -24,17 +24,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js (LTS)
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: pnpm
-
       - name: Setup pnpm 10.11.0
         uses: pnpm/action-setup@v4
         with:
           version: 10.11.0
           run_install: false
+
+      - name: Setup Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- configure pnpm before `actions/setup-node` enables the pnpm dependency cache
- allow the TS SDK latest-compatibility workflow to advance beyond Node setup

## Validation
- Parsed `.github/workflows/ts-sdk-latest-compatibility.yml` as YAML
- Verified pnpm setup precedes `actions/setup-node` cache configuration
- Ran `git diff --check`