### PR TITLE
docs: improve SDK onboarding and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,113 @@
-# Script Composer SDK
+# Aptos Script Composer SDK
 
-A monorepo containing the Script Composer SDK and example implementations.
+[![CI](https://github.com/aptos-labs/script-composer-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/aptos-labs/script-composer-sdk/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@aptos-labs/script-composer-sdk)](https://www.npmjs.com/package/@aptos-labs/script-composer-sdk)
 
-## Project Structure
+Compose multiple Aptos Move entry-function calls into one script transaction. The SDK builds on [`@aptos-labs/ts-sdk`](https://www.npmjs.com/package/@aptos-labs/ts-sdk) and the Script Composer pack, and supports single-signer, multi-agent, and fee-payer transactions.
 
-This is a monorepo managed with pnpm workspaces, containing:
-- `packages/*`: Core SDK packages
-- `examples/*`: Example implementations and usage
+## Why use it?
 
-## Prerequisites
+A transaction normally invokes one entry function. Script Composer lets an application describe several compatible calls, including calls that consume values returned by earlier calls, and execute them atomically in one Aptos transaction.
 
-- Node.js (Latest LTS version recommended)
-- pnpm (v10.11.0 or later)
+## Install
 
-## Installation
-
-1. Clone the repository:
 ```bash
-git clone [repository-url]
-cd script-composer-sdk
+pnpm add @aptos-labs/script-composer-sdk @aptos-labs/ts-sdk
 ```
 
-2. Install dependencies:
-```bash
-pnpm install
+The SDK supports `@aptos-labs/ts-sdk` major versions 3 through 7. Use Node.js 22 or a current LTS release for this repository and its examples.
+
+## Quick start
+
+This example builds a transaction that transfers APT on Testnet. By default, the composer fetches the Move ABI and bytecode it needs from the configured network. Building a transaction does **not** sign or submit it.
+
+```ts
+import { Aptos, AptosConfig, Network } from '@aptos-labs/ts-sdk';
+import { BuildScriptComposerTransaction, CallArgument } from '@aptos-labs/script-composer-sdk';
+
+const config = new AptosConfig({ network: Network.TESTNET });
+const sender = '0x...';
+const recipient = '0x...';
+
+const transaction = await BuildScriptComposerTransaction({
+  sender,
+  aptosConfig: config,
+  builder: async (composer) => {
+    await composer.addBatchedCalls({
+      function: '0x1::aptos_account::transfer',
+      functionArguments: [CallArgument.newSigner(0), recipient, 1_000],
+    });
+    return composer;
+  },
+});
+
+// Safe for a quick integration check; no transaction is submitted.
+const result = await new Aptos(config).transaction.simulate.simple({ transaction });
+console.log(result);
 ```
+
+To submit a transaction, sign the returned transaction with the appropriate accounts using `@aptos-labs/ts-sdk`, then submit the resulting authenticator. See the [Aptos TypeScript SDK documentation](https://aptos.dev/en/build/sdks/ts-sdk) for account management and signing APIs.
+
+## Core concepts
+
+### Automatic and manual module loading
+
+`addBatchedCalls` uses `allowFetch: true` by default. The composer fetches missing Move module ABI and bytecode from the configured full node, which is convenient for connected applications.
+
+For offline or controlled environments, set `options.allowFetch` to `false` and provide both `moduleAbi` and `moduleBytecodes`. You can also preload modules with `getModuleInner` and `composer.storeModule` as shown in the Node example.
+
+### Connecting calls with returned values
+
+`addBatchedCalls` returns `CallArgument[]`. Pass a returned item into a later call's `functionArguments` to compose dependent operations without leaving the transaction:
+
+```ts
+const [createdObject] = await composer.addBatchedCalls({ /* first call */ });
+await composer.addBatchedCalls({
+  function: '0x...::module::consume',
+  functionArguments: [createdObject],
+});
+```
+
+### Signers, multi-agent transactions, and fee payers
+
+- `CallArgument.newSigner(0)` refers to the primary sender. Secondary signers are indexed starting at `1`.
+- Use `BuildScriptComposerTransaction` for a normal, single-signer transaction.
+- Use `BuildScriptComposerMultiAgentTransaction` when calls require secondary signers and/or a fee payer. It returns a transaction that each required account must sign before submission.
+- A fee payer pays gas; it is not an additional Move-function signer unless the Move call itself requires one.
+
+## Examples
+
+| Example | Demonstrates | Run from repository root |
+| --- | --- | --- |
+| [Node.js](examples/nodejs) | Auto-fetch and preloaded-module composition, then simulation on Testnet | `pnpm --filter example-nodejs start` |
+| [Multi-agent Node.js](examples/multi-agent-nodejs) | Secondary signers and fee-payer transaction construction | `pnpm --filter example-multi-agent-nodejs start` |
+| [React](examples/react-project) | Browser UI for composing transactions | `pnpm --filter react-project dev` |
+| [Next.js](examples/nextjs-project) | Browser UI including multi-agent flows | `pnpm --filter nextjs-project dev` |
+
+Examples construct or simulate transactions only unless their documentation explicitly says otherwise. Review function arguments, account addresses, and network configuration before adapting an example to submit real transactions.
 
 ## Development
 
-### Building the Project
-
-To build all packages:
 ```bash
+git clone https://github.com/aptos-labs/script-composer-sdk.git
+cd script-composer-sdk
+pnpm install
 pnpm build
-```
-
-### Running Tests
-
-To run tests across all packages:
-```bash
 pnpm test
 ```
 
-## Project Setup
+The repository is a pnpm workspace. SDK source is in `packages/sdk`; runnable applications live under `examples`.
 
-1. After cloning the repository, run `pnpm install` to install all dependencies
-2. Run `pnpm build` to build all packages
-3. You can now run tests using `pnpm test`
+## Releases
 
-## Release Automation
+This project uses [Changesets](https://github.com/changesets/changesets). Changes that affect the published SDK should include a changeset:
 
-This repository uses a Changesets-based release flow (`.github/workflows/release.yml`).
+```bash
+pnpm changeset
+```
 
-### How it works
+Merging changesets to `main` creates or updates a version PR; merging that PR publishes the package through the repository release workflow.
 
-1. Add a changeset in your feature PR:
-   - run `pnpm changeset`
-   - select `@aptos-labs/script-composer-sdk`
-   - choose version bump type and summary
-2. Merge PRs with changesets into `main`.
-3. On push to `main`, release workflow runs `changesets/action`:
-   - if unpublished changesets exist, it creates/updates a Version Packages release PR
-   - after that release PR is merged, workflow publishes to npm
-4. You can manually re-run via `workflow_dispatch` for retries.
+## Support and security
 
-### Important notes
-
-- This workflow no longer uses tag-driven release channels.
-- Test tag/test dist-tag channel is intentionally disabled.
-- npm package versions are immutable; even if unpublished, `name@version` cannot be reused.
-
-### Required repository setup
-
-1. Configure GitHub App credentials for release automation:
-   - repository variable: `APTOS_LABS_BOT_APP_ID`
-   - repository secret: `APTOS_LABS_BOT_APP_PRIVATE_KEY`
-2. Configure npm Trusted Publisher for this repository and workflow file `release.yml`.
-3. Keep `main` protected (PR required, required checks, no direct pushes).
+For defects and feature requests, open a [GitHub issue](https://github.com/aptos-labs/script-composer-sdk/issues). Do not report security vulnerabilities in a public issue; follow Aptos Labs' security reporting process instead.

--- a/examples/multi-agent-nodejs/README.md
+++ b/examples/multi-agent-nodejs/README.md
@@ -1,267 +1,46 @@
-# Script Composer SDK - Multi-Agent Transaction Example
+# Multi-agent Node.js example
 
-This example demonstrates how to use the Script Composer SDK to build multi-agent transactions on the Aptos blockchain. Multi-agent transactions allow multiple signers to participate in a transaction, with optional fee payer support for sponsored transactions.
+This example constructs several Aptos multi-agent transaction variants using the Script Composer SDK:
 
-## Overview
+1. **Primary and secondary signer**: calls reference `CallArgument.newSigner(0)` for the sender and `CallArgument.newSigner(1)` for the first secondary signer.
+2. **Multiple secondary signers**: demonstrates supplying more than one secondary signer address.
+3. **Fee payer**: demonstrates a sponsored transaction where another account pays the gas fee.
+4. **Secondary signers and fee payer**: combines both transaction features.
 
-Multi-agent transactions are a powerful feature of the Aptos blockchain that enable:
-- **Multiple Signers**: Transactions that require approval from multiple parties
-- **Sponsored Transactions**: Transactions where a third party pays for gas fees
-- **Complex Workflows**: Support for sophisticated transaction patterns
+The script builds transactions and prints their signer metadata. It does **not** sign, simulate, or submit them, so it is safe to run without private keys.
 
 ## Prerequisites
 
 - Node.js 22 or later
-- npm, yarn, or pnpm
-- Access to Aptos Testnet (for testing)
+- pnpm 10.11.0 or later
+- Network access to Aptos Testnet; the example fetches the `0x1::aptos_account` module
 
-## Installation
+## Run
 
-1. Navigate to the example directory:
+From the repository root:
+
 ```bash
-cd examples/multi-agent-nodejs
-```
-
-2. Install dependencies from the workspace root:
-```bash
-# From the repository root
 pnpm install
+pnpm build
+pnpm --filter example-multi-agent-nodejs start
 ```
 
-Or install directly in this directory:
-```bash
-npm install
-# or
-yarn install
-# or
-pnpm install
-```
-
-## Running the Example
-
-To run all examples:
+Or, from this directory after installing workspace dependencies from the repository root:
 
 ```bash
 pnpm start
-# or
-npm run start
-# or
-tsx index.ts
 ```
 
-## Examples Included
+The output identifies each constructed transaction's secondary signer addresses and fee payer, if present.
 
-This example demonstrates four different multi-agent transaction scenarios:
+## Signing and submitting a multi-agent transaction
 
-### Example 1: Basic Multi-Agent Transaction
+`BuildScriptComposerMultiAgentTransaction` returns an unsigned transaction. Before submission, use `@aptos-labs/ts-sdk` to collect authenticators from:
 
-Creates a multi-agent transaction with a sender and secondary signers (no fee payer). This demonstrates a basic multi-agent transaction setup with multiple signers.
+- the primary sender;
+- every address in `secondarySignerAddresses`; and
+- `feePayerAddress`, if provided.
 
-**Key Features:**
-- Primary sender
-- One secondary signer
-- No fee payer
-- Basic multi-agent configuration
+A fee payer is responsible for gas but does not occupy a `CallArgument.newSigner(...)` index. Signer index `0` is always the primary sender; secondary signers begin at index `1`.
 
-**Use Cases:**
-- Testing multi-agent transaction structure
-- Understanding basic multi-agent setup
-- Preparing for more complex scenarios
-
-### Example 2: Multi-Agent with Secondary Signers
-
-Creates a multi-agent transaction with a sender and multiple secondary signers. This shows how to add additional signers to a transaction.
-
-**Key Features:**
-- Primary sender
-- One or more secondary signers
-- No fee payer
-- Multiple approvals required
-
-**Use Cases:**
-- Multi-signature wallets
-- Governance transactions requiring multiple approvals
-- Escrow services
-- Shared account management
-
-### Example 3: Multi-Agent with Fee Payer (Sponsored Transaction)
-
-Creates a multi-agent transaction with a sender, secondary signers, and a fee payer. This demonstrates sponsored transaction pattern where a third party pays for gas.
-
-**Key Features:**
-- Primary sender
-- One secondary signer
-- Fee payer (sponsor)
-- Gas fees paid by sponsor
-
-**Use Cases:**
-- User onboarding (dApp pays for first transactions)
-- Promotional campaigns
-- Reducing user friction
-- Enterprise applications
-
-### Example 4: Complete Multi-Agent Transaction
-
-Creates a full multi-agent transaction with sender, secondary signers, and fee payer. This demonstrates the most complex multi-agent transaction structure.
-
-**Key Features:**
-- Primary sender
-- Multiple secondary signers
-- Fee payer (sponsor)
-- Complete multi-agent setup
-
-**Use Cases:**
-- Complex governance workflows
-- Enterprise multi-party transactions
-- Advanced dApp features
-- Sophisticated transaction patterns
-
-## Code Structure
-
-```
-multi-agent-nodejs/
-├── index.ts          # Main example file with all four scenarios
-├── package.json      # Project dependencies
-└── README.md         # This documentation
-```
-
-## Key Concepts
-
-### Multi-Agent Transactions
-
-Multi-agent transactions differ from simple transactions in that they:
-- Support multiple signers (primary sender + secondary signers)
-- Can have a fee payer separate from the sender
-- Require signatures from all parties before execution
-- Enable complex transaction workflows
-
-### Transaction Building Process
-
-1. **Fetch Module**: Get the required Move module from the blockchain
-2. **Build Transaction**: Use `BuildScriptComposerMultiAgentTransaction` to construct the transaction
-3. **Configure Signers**: Specify primary sender, secondary signers, and optional fee payer
-4. **Add Function Calls**: Use the composer to add batched function calls
-5. **Return Transaction**: Get the `MultiAgentTransaction` object ready for signing
-
-### Signing and Submission
-
-**Note**: This example only builds transactions. To actually submit them:
-
-1. Sign the transaction with the sender's private key
-2. Sign with all secondary signers' private keys
-3. Sign with the fee payer's private key (if applicable)
-4. Submit the fully signed transaction to the network
-
-For simulation, use `aptos.transaction.simulate.multiAgent()` with the appropriate public keys.
-
-## API Reference
-
-### BuildScriptComposerMultiAgentTransaction
-
-```typescript
-BuildScriptComposerMultiAgentTransaction(args: {
-  sender: AccountAddressInput;                    // Required: Primary sender address
-  builder: (composer: AptosScriptComposer) => Promise<AptosScriptComposer>;  // Required: Builder function
-  aptosConfig: AptosConfig;                       // Required: Aptos configuration
-  options?: InputGenerateTransactionOptions;       // Optional: Transaction options
-  secondarySignerAddresses?: Array<AccountAddressInput>;  // Optional: Secondary signer addresses
-  feePayerAddress?: AccountAddressInput;          // Optional: Fee payer address
-}): Promise<MultiAgentTransaction>
-```
-
-### Parameters
-
-- **sender** (required): The primary account address that will sign the transaction
-- **builder** (required): Async function that receives and returns an `AptosScriptComposer` instance
-- **aptosConfig** (required): Aptos configuration for network and API settings
-- **options** (optional): Transaction generation options (gas price, expiration, etc.)
-- **secondarySignerAddresses** (optional): Array of secondary signer addresses for multi-agent transactions
-- **feePayerAddress** (optional): Account address that sponsors the transaction's gas fees
-
-### Return Value
-
-Returns a `MultiAgentTransaction` object containing:
-- `rawTransaction`: The raw transaction data
-- `secondarySignerAddresses`: Array of secondary signer addresses
-- `feePayerAddress`: Optional fee payer address
-
-## Dependencies
-
-The example uses the following main dependencies:
-
-- **@aptos-labs/script-composer-sdk**: For building multi-agent transactions
-- **@aptos-labs/ts-sdk**: For interacting with the Aptos blockchain
-- **tsx**: For running TypeScript files directly
-
-## Important Notes
-
-### Test Addresses
-
-The example uses test addresses (`0x1`, `0x2`, etc.) for demonstration purposes. In production:
-- Use actual account addresses
-- Ensure accounts have sufficient balance
-- Verify account permissions
-
-### Transaction Signing
-
-This example only builds transactions. To actually execute them:
-- Sign with the sender's private key
-- Sign with all secondary signers' private keys
-- Sign with the fee payer's private key (if applicable)
-- Submit the fully signed transaction
-
-### Network Configuration
-
-The example uses `Network.TESTNET` by default. To use a different network:
-- Change `Network.TESTNET` to `Network.MAINNET` or `Network.DEVNET`
-- Ensure you have access to the selected network
-- Update any network-specific addresses or configurations
-
-### Error Handling
-
-The examples include basic error handling. In production:
-- Implement comprehensive error handling
-- Validate all inputs
-- Handle network errors gracefully
-- Provide user-friendly error messages
-
-## Next Steps
-
-After understanding these examples, you can:
-
-1. **Sign Transactions**: Learn how to sign multi-agent transactions with multiple keys
-2. **Submit Transactions**: Submit signed transactions to the Aptos network
-3. **Simulate Transactions**: Use `aptos.transaction.simulate.multiAgent()` to test before submission
-4. **Build Complex Flows**: Create sophisticated multi-agent transaction workflows for your dApp
-5. **Integrate with Wallets**: Connect with wallet providers for signing
-6. **Handle Errors**: Implement robust error handling and user feedback
-
-## Additional Resources
-
-- [Aptos Documentation](https://aptos.dev/)
-- [Script Composer SDK Documentation](../../README.md)
-- [Aptos TypeScript SDK](https://github.com/aptos-labs/aptos-ts-sdk)
-- [Multi-Agent Transaction Guide](https://aptos.dev/guides/transaction-management)
-
-## Troubleshooting
-
-### Common Issues
-
-**Issue**: "Module not found"
-- **Solution**: Ensure the module exists on the network and the address is correct
-
-**Issue**: "Invalid address format"
-- **Solution**: Verify addresses are in the correct format (0x prefix, valid hex)
-
-**Issue**: "Insufficient balance"
-- **Solution**: Ensure accounts have sufficient balance for gas fees
-
-**Issue**: "Transaction build failed"
-- **Solution**: Check all parameters are valid and the builder function is correct
-
-## Support
-
-For issues and questions:
-- Check the [main repository README](../../README.md)
-- Review the [Aptos documentation](https://aptos.dev/)
-- Open an issue on GitHub
+The example uses placeholder addresses and a transfer to `0x1`. Replace them with accounts and Move functions that match your application's authorization model before signing or submitting a transaction.

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -1,53 +1,41 @@
-# Script Composer SDK Node.js Example
+# Node.js example
 
-This example demonstrates how to use the Script Composer SDK in a Node.js environment to build and simulate transactions on the Aptos blockchain.
+A minimal Node.js walkthrough for composing an Aptos transaction and simulating it on Testnet. It runs two equivalent flows:
+
+1. **Preloaded modules**: fetches `0x1::aptos_account` once, stores it in the composer, then disables automatic module fetching.
+2. **Automatic modules**: lets the composer fetch the required ABI and bytecode itself.
+
+Neither flow signs nor submits a transaction. The simulated transfer deliberately uses `0x1` as both sender and recipient, so treat it as a construction and simulation example rather than a payment workflow.
 
 ## Prerequisites
 
 - Node.js 22 or later
-- npm or yarn
+- pnpm 10.11.0 or later
+- Network access to Aptos Testnet
 
-## Installation
+## Run
 
-1. Navigate to the example directory:
-```bash
-cd examples/nodejs
-```
-
-2. Install dependencies:
-```bash
-npm install
-```
-
-## Running the Example
-
-To run the example:
+From the repository root:
 
 ```bash
-tsx index.ts
+pnpm install
+pnpm build
+pnpm --filter example-nodejs start
 ```
 
-## What This Example Does
+Or, from this directory after installing workspace dependencies from the repository root:
 
-This example demonstrates:
+```bash
+pnpm start
+```
 
-1. Fetching a module from the Aptos blockchain
-2. Building a transaction using the Script Composer SDK
-3. Simulating the transaction on the Aptos testnet
+Expected output includes `simulate_result (cache)` and `simulate_result (fetch)`. A simulation result can contain a VM failure because the placeholder sender is not a funded account; that still verifies the composed transaction can be constructed and sent to the simulation endpoint.
 
-The example specifically:
-- Fetches the `aptos_account` module from the Aptos blockchain
-- Creates a transaction that attempts to transfer 1 APT from account `0x1` to itself
-- Simulates the transaction to see the expected outcome
+## Adapting it for your application
 
-## Code Structure
+1. Replace the placeholder sender and recipient with real account addresses.
+2. Replace the transfer with your Move entry functions and arguments.
+3. Build the transaction using `BuildScriptComposerTransaction`.
+4. Sign and submit the returned transaction with `@aptos-labs/ts-sdk` only after reviewing the payload and required signer permissions.
 
-- `index.ts`: Contains the main example code
-- `package.json`: Defines project dependencies
-
-## Dependencies
-
-The example uses the following main dependencies:
-- `script-composer-sdk`: For building transactions
-- `@aptos-labs/ts-sdk`: For interacting with the Aptos blockchain
-- `@aptos-labs/script-composer-pack`: For transaction building utilities 
+For an offline or controlled module-loading workflow, keep `allowFetch: false` and supply `moduleAbi` plus `moduleBytecodes`. For connected applications, omit the option or use `allowFetch: true`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,38 @@
+# @aptos-labs/script-composer-sdk
+
+Compose multiple Aptos Move entry-function calls into a single script transaction.
+
+For full documentation, examples, and contribution information, see the [Script Composer SDK repository](https://github.com/aptos-labs/script-composer-sdk).
+
+## Install
+
+```bash
+pnpm add @aptos-labs/script-composer-sdk @aptos-labs/ts-sdk
+```
+
+The package supports `@aptos-labs/ts-sdk` major versions 3 through 7.
+
+## Build a transaction
+
+```ts
+import { AptosConfig, Network } from '@aptos-labs/ts-sdk';
+import { BuildScriptComposerTransaction, CallArgument } from '@aptos-labs/script-composer-sdk';
+
+const aptosConfig = new AptosConfig({ network: Network.TESTNET });
+
+const transaction = await BuildScriptComposerTransaction({
+  sender: '0x...',
+  aptosConfig,
+  builder: async (composer) => {
+    await composer.addBatchedCalls({
+      function: '0x1::aptos_account::transfer',
+      functionArguments: [CallArgument.newSigner(0), '0x...', 1_000],
+    });
+    return composer;
+  },
+});
+```
+
+`addBatchedCalls` automatically fetches missing Move module metadata by default. To work offline, set `options.allowFetch` to `false` and provide `moduleAbi` and `moduleBytecodes`.
+
+The returned transaction is unsigned. Sign and submit it with `@aptos-labs/ts-sdk`. Use `BuildScriptComposerMultiAgentTransaction` when secondary signers or a fee payer are required.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aptos-labs/script-composer-sdk",
   "version": "0.3.5",
-  "description": "Script Composer SDK",
+  "description": "Compose multiple Aptos Move calls into a single transaction",
   "repository": {
     "type": "git",
     "url": "https://github.com/aptos-labs/script-composer-sdk"
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist",
+    "README.md",
     "package.json"
   ],
   "scripts": {
@@ -37,8 +38,16 @@
     "fmt": "prettier --write \"**/*.{ts,tsx,json,md}\"",
     "fmt:check": "prettier --check \"**/*.{ts,tsx,json,md}\""
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "aptos",
+    "move",
+    "blockchain",
+    "transactions",
+    "transaction-composer",
+    "multi-agent",
+    "fee-payer"
+  ],
+  "author": "Aptos Labs",
   "license": "ISC",
   "peerDependencies": {
     "@aptos-labs/aptos-dynamic-transaction-composer": "^0.1.7",
@@ -57,5 +66,9 @@
     "tsup": "8.5.0",
     "typescript": "5.8.3",
     "vitest": "3.2.6"
+  },
+  "homepage": "https://github.com/aptos-labs/script-composer-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/aptos-labs/script-composer-sdk/issues"
   }
 }


### PR DESCRIPTION
## Summary
- rewrite the root README around installation, a transaction-building quick start, module loading, signer semantics, and example discovery
- add a package README and complete npm metadata so consumers receive useful documentation with the published package
- modernize Node and multi-agent example guides with pnpm workspace commands, safe execution expectations, and signing guidance

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @aptos-labs/script-composer-sdk fmt:check`
- `pnpm --filter @aptos-labs/script-composer-sdk build`
- packed the SDK and verified the tarball includes `README.md` and distribution artifacts
- `git diff --check`