### PR TITLE
feat: add configurable Node quick start

### DIFF
--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -1,53 +1,52 @@
-# Script Composer SDK Node.js Example
+# Node.js quick start
 
-This example demonstrates how to use the Script Composer SDK in a Node.js environment to build and simulate transactions on the Aptos blockchain.
+This runnable quick start composes `0x1::aptos_account::transfer` and simulates it on Aptos Testnet. It runs the same transaction twice:
+
+1. **Preloaded module:** fetches `0x1::aptos_account`, stores it in the composer, and sets `allowFetch: false`.
+2. **Automatic module loading:** lets `addBatchedCalls` fetch required Move metadata; `allowFetch` defaults to `true`.
+
+The script never signs or submits a transaction.
 
 ## Prerequisites
 
 - Node.js 22 or later
-- npm or yarn
+- pnpm 10.11.0 or later
+- Network access to Aptos Testnet or Mainnet
 
-## Installation
+## Run
 
-1. Navigate to the example directory:
-```bash
-cd examples/nodejs
-```
-
-2. Install dependencies:
-```bash
-npm install
-```
-
-## Running the Example
-
-To run the example:
+From the repository root:
 
 ```bash
-tsx index.ts
+pnpm install
+pnpm build
+pnpm --filter example-nodejs start
 ```
 
-## What This Example Does
+The default configuration uses `0x1` as both sender and recipient on Testnet and transfers one octa. It is intentionally safe because the transaction is simulated only.
 
-This example demonstrates:
+## Configuration
 
-1. Fetching a module from the Aptos blockchain
-2. Building a transaction using the Script Composer SDK
-3. Simulating the transaction on the Aptos testnet
+Set environment variables before running to use different public account addresses or network settings:
 
-The example specifically:
-- Fetches the `aptos_account` module from the Aptos blockchain
-- Creates a transaction that attempts to transfer 1 APT from account `0x1` to itself
-- Simulates the transaction to see the expected outcome
+| Variable | Default | Description |
+| --- | --- | --- |
+| `APTOS_NETWORK` | `testnet` | `testnet` or `mainnet` |
+| `APTOS_SENDER` | `0x1` | Sender address used to build and simulate the transaction |
+| `APTOS_RECIPIENT` | sender address | Recipient address |
+| `APTOS_AMOUNT_OCTAS` | `1` | Positive integer transfer amount in octas |
 
-## Code Structure
+For example:
 
-- `index.ts`: Contains the main example code
-- `package.json`: Defines project dependencies
+```bash
+APTOS_SENDER=0x... APTOS_RECIPIENT=0x... APTOS_AMOUNT_OCTAS=1000 \
+  pnpm --filter example-nodejs start
+```
 
-## Dependencies
+## Expected output
 
-The example uses the following main dependencies:
-- `script-composer-sdk`: For building transactions
-- `@aptos-labs/ts-sdk`: For interacting with the Aptos blockchain
-- `@aptos-labs/script-composer-pack`: For transaction building utilities 
+A successful run prints one simulation summary for the preloaded module path and one for automatic module loading. Both should report `success: true` when using the default Testnet configuration.
+
+## Use this in an application
+
+Replace the transfer call with your Move entry functions, then build a transaction with `BuildScriptComposerTransaction`. The returned transaction is unsigned. Use `@aptos-labs/ts-sdk` to collect signatures and submit only after reviewing the payload and signer permissions.

--- a/examples/nodejs/index.ts
+++ b/examples/nodejs/index.ts
@@ -1,88 +1,81 @@
-import { BuildScriptComposerTransaction, CallArgument, getModuleInner } from '@aptos-labs/script-composer-sdk';
-import { AptosConfig, Network, Aptos } from "@aptos-labs/ts-sdk"
+import {
+  AccountAddress,
+  Aptos,
+  AptosConfig,
+  Network,
+  type MoveModuleBytecode,
+} from '@aptos-labs/ts-sdk';
+import {
+  BuildScriptComposerTransaction,
+  CallArgument,
+  getModuleInner,
+} from '@aptos-labs/script-composer-sdk';
 
-// Example using local cache
-async function mainWithCache() {
-  const aptos_account_module = await getModuleInner({
-    aptosConfig: new AptosConfig({ network: Network.TESTNET }),
+const networkName = process.env.APTOS_NETWORK?.toLowerCase() ?? 'testnet';
+const network = networkName === 'mainnet' ? Network.MAINNET : Network.TESTNET;
+const sender = process.env.APTOS_SENDER ?? '0x1';
+const recipient = process.env.APTOS_RECIPIENT ?? sender;
+const amount = Number(process.env.APTOS_AMOUNT_OCTAS ?? '1');
+const aptosConfig = new AptosConfig({ network });
+const aptos = new Aptos(aptosConfig);
+
+if (!Number.isSafeInteger(amount) || amount <= 0) {
+  throw new Error('APTOS_AMOUNT_OCTAS must be a positive safe integer.');
+}
+
+AccountAddress.from(sender);
+AccountAddress.from(recipient);
+
+async function buildTransfer({ module }: { module?: MoveModuleBytecode }) {
+  return BuildScriptComposerTransaction({
+    sender,
+    aptosConfig,
+    builder: async (composer) => {
+      if (module) composer.storeModule(module, '0x1::aptos_account');
+
+      await composer.addBatchedCalls({
+        function: '0x1::aptos_account::transfer',
+        functionArguments: [CallArgument.newSigner(0), recipient, amount],
+        ...(module
+          ? {
+              options: { allowFetch: false },
+              moduleAbi: module.abi,
+              moduleBytecodes: [module.bytecode],
+            }
+          : {}),
+      });
+      return composer;
+    },
+  });
+}
+
+async function simulate(label: string, module?: MoveModuleBytecode) {
+  const transaction = await buildTransfer({ module });
+  const [result] = await aptos.transaction.simulate.simple({ transaction });
+  console.log(`\n${label}`);
+  console.log(`  success: ${result.success}`);
+  console.log(`  status: ${result.vm_status}`);
+  console.log(`  gas used: ${result.gas_used}`);
+  console.log(`  sender: ${result.sender}`);
+}
+
+async function main() {
+  console.log(`Composing a ${amount}-octa transfer on ${networkName}.`);
+  console.log(`Sender: ${sender}`);
+  console.log(`Recipient: ${recipient}`);
+  console.log('This example only simulates; it never signs or submits a transaction.');
+
+  const module = await getModuleInner({
+    aptosConfig,
     accountAddress: '0x1',
     moduleName: 'aptos_account',
   });
-  try {
-   const tx = await BuildScriptComposerTransaction({
-    sender: "0x1",
-    builder: async (composer) => {
-      // Store the module in cache first
-      composer.storeModule(aptos_account_module, "0x1::aptos_account");
-      await composer.addBatchedCalls({
-        function: '0x1::aptos_account::transfer',
-        functionArguments: [ CallArgument.newSigner(0) ,'0x1', 1],
-        typeArguments: [],
-        // Do not allow auto fetch
-        options: {
-          allowFetch: false,
-        },
-        moduleAbi: aptos_account_module.abi,
-        moduleBytecodes: [aptos_account_module.bytecode],
-      });
-      return composer
-    },
-    aptosConfig: new AptosConfig({
-      network: Network.TESTNET,
-    }),
-   });
 
-   const aptos = new Aptos(new AptosConfig({
-    network: Network.TESTNET,
-   }));
-
-   const simulate_result = await aptos.transaction.simulate.simple({
-    transaction: tx,
-   })
-
-   console.log('simulate_result (cache):', simulate_result)
-    
-  } catch (error) {
-    console.error('Error (cache):', error);
-  }
+  await simulate('Preloaded module (allowFetch: false)', module);
+  await simulate('Automatic module loading (allowFetch defaults to true)');
 }
 
-// Example using auto fetch
-async function mainWithFetch() {
-  try {
-   const tx = await BuildScriptComposerTransaction({
-    sender: "0x1",
-    builder: async (composer) => {
-      await composer.addBatchedCalls({
-        function: '0x1::aptos_account::transfer',
-        functionArguments: [ CallArgument.newSigner(0) ,'0x1', 1],
-        typeArguments: [],
-        // Allow auto fetch
-        options: {
-          allowFetch: true,
-        }
-      });
-      return composer
-    },
-    aptosConfig: new AptosConfig({
-      network: Network.TESTNET,
-    }),
-   });
-
-   const aptos = new Aptos(new AptosConfig({
-    network: Network.TESTNET,
-   }));
-
-   const simulate_result = await aptos.transaction.simulate.simple({
-    transaction: tx,
-   })
-
-   console.log('simulate_result (fetch):', simulate_result)
-    
-  } catch (error) {
-    console.error('Error (fetch):', error);
-  }
-}
-
-await mainWithCache();
-await mainWithFetch();
+main().catch((error: unknown) => {
+  console.error('\nExample failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- make the Node quick start configurable through network, sender, recipient, and amount environment variables
- present concise simulation output and validate supplied account addresses and transfer amounts
- document the exact safe simulation workflow and expected successful output

## Validation
- `pnpm --filter @aptos-labs/script-composer-sdk fmt:check`
- `pnpm build`
- `pnpm --filter example-nodejs start`
  - verified both preloaded-module and automatic-module-loading simulations execute successfully on Testnet
- `git diff --check`